### PR TITLE
Update `auth.service.ts` imports to recent rxjs

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Headers, Http } from '@angular/http';
 import { User } from '../models/user';
-import 'rxjs/add/operator/toPromise';
+import 'es6/add/operator/toPromise';
 
 @Injectable()
 export class AuthService {


### PR DESCRIPTION
Most recent angular cli will not find `'rxjs/add/operator/toPromise'` as this is ES6 functionality.
See http://reactivex.io/rxjs/file/es6/add/operator/toPromise.js.html

This probably also means some work on the blog post :)